### PR TITLE
Disable mipmap for sky images

### DIFF
--- a/modules/AssetExporter.py
+++ b/modules/AssetExporter.py
@@ -859,7 +859,8 @@ def exportSkybox(skyName: str, mapName: str, worldSpawnSettings, dir: SourceDir,
             "semantic": "HDR",
             "compressionMethod": "uncompressed",
             "coreSemantic": "HDR",
-            "streamable": "1"
+            "streamable": "1",
+            "noMipMaps": "1"
         })
         gdt.add(f"{mapName}_sky_mtl", "material", {
             "materialCategory": "Geometry",


### PR DESCRIPTION
Disable mipmap for sky images
ERROR: (image texture_assets\\corvid\\i_dod_colmar_d_sky.tif) mip maps not supported for non power of two

^1Could not convert image 'i_dod_colmar_d_sky'.
  image:i_dod_colmar_d_sky
    material:mc/dod_colmar_d_sky_mtl
      xmodel:dod_colmar_d_skybox
        gfx_map:maps/zm/zm_colmar.d3dbsp